### PR TITLE
Added Limitations handling

### DIFF
--- a/src/Dan.Plugin.Bits/Config/PluginConstants.cs
+++ b/src/Dan.Plugin.Bits/Config/PluginConstants.cs
@@ -19,6 +19,7 @@ public static class PluginConstants
 
     public const string PantUtlegg = "PantUtlegg";
 
+    public const string Limitations = "Limitations";
 
     public const string DefaultValue = "default";
 }

--- a/src/Dan.Plugin.Bits/Config/Settings.cs
+++ b/src/Dan.Plugin.Bits/Config/Settings.cs
@@ -24,4 +24,5 @@ public class Settings
         get => GithubPatValue ?? new PluginKeyVault(KeyVaultName).Get(GithubPatName).Result;
         init => GithubPatValue = value;
     }
+    public string LimitationsResourceFile { get; init; }
 }

--- a/src/Dan.Plugin.Bits/Metadata.cs
+++ b/src/Dan.Plugin.Bits/Metadata.cs
@@ -75,6 +75,28 @@ public class Metadata : IEvidenceSourceMetadata
             },
             new EvidenceCode()
             {
+                EvidenceCodeName = PluginConstants.Limitations,
+                EvidenceSource = PluginConstants.SourceName,
+                BelongsToServiceContexts = [ServiceContext],
+                Values =
+                [
+                    new EvidenceValue()
+                    {
+                        EvidenceValueName = PluginConstants.DefaultValue,
+                        ValueType = EvidenceValueType.JsonSchema,
+                        JsonSchemaDefintion = EvidenceValue.SchemaFromObject<LimitationsList>(Formatting.Indented)
+                    }
+                ],
+                AuthorizationRequirements =
+                [
+                    new MaskinportenScopeRequirement()
+                    {
+                        RequiredScopes = [ScopeKontrollinformasjon]
+                    }
+                ]
+            },
+            new EvidenceCode()
+            {
                 EvidenceCodeName = PluginConstants.KontrollinformasjonV2,
                 EvidenceSource = PluginConstants.SourceName,
                 BelongsToServiceContexts = [ServiceContext],

--- a/src/Dan.Plugin.Bits/Models/CustomConverters.cs
+++ b/src/Dan.Plugin.Bits/Models/CustomConverters.cs
@@ -1,9 +1,45 @@
 using System;
 using System.Globalization;
 using FileHelpers;
+using Newtonsoft.Json;
 
 
 namespace Dan.Plugin.Bits.Models;
+
+// Deserializes an apiResponseStatus string against the ApiResponseStatus enum.
+// Unrecognized value falls back to ApiResponseStatus.Unknown
+public sealed class ApiResponseStatusConverter : JsonConverter
+{
+    public override bool CanConvert(Type objectType)
+    {
+        return objectType == typeof(ApiResponseStatus) || objectType == typeof(ApiResponseStatus?);
+    }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+        if (reader.TokenType == JsonToken.Null)
+            return null;
+
+        var text = reader.Value?.ToString();
+
+        if (string.IsNullOrWhiteSpace(text))
+            return null;
+
+        return Enum.TryParse<ApiResponseStatus>(text, ignoreCase: true, out var status) ? status : ApiResponseStatus.Unknown;
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+        if (value == null)
+        {
+            writer.WriteNull();
+        }
+        else
+        {
+            writer.WriteValue(value.ToString());
+        }
+    }
+}
 
 public sealed class DateTimeOffsetConverter : ConverterBase
 {

--- a/src/Dan.Plugin.Bits/Models/Endpoints.cs
+++ b/src/Dan.Plugin.Bits/Models/Endpoints.cs
@@ -39,6 +39,15 @@ public class EndpointsList
     public int Total { get; set; }
 }
 
+public class LimitationsList
+{
+    [JsonProperty("limitations")]
+    public IReadOnlyList<Limitation> Limitations { get; set; }
+
+    [JsonProperty("total")]
+    public int Total { get; set; }
+}
+
 public class EndpointExternal
 {
     [JsonProperty("orgNo")]
@@ -62,5 +71,29 @@ public class EndpointExternal
     [JsonProperty("toDate", NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
     public DateTimeOffset? ToDate { get; set; }
 
+    [JsonProperty("limitations", NullValueHandling = NullValueHandling.Ignore, DefaultValueHandling = DefaultValueHandling.Ignore)]
+    public List<Limitation> Limitations { get; set; }
+}
 
+public class Limitation
+{
+    [JsonProperty("limitationId")]
+    public string LimitationId { get; set; }
+    [JsonProperty("limitationGroupId")]
+    public string? LimitationGroupId { get; set; } = null;
+    [JsonProperty("area")]
+    public string Area{ get; set; }
+    [JsonProperty("apiResponseStatus")]
+    public string? ApiResponseStatus { get; set; } = null;
+    [JsonProperty("description")]
+    public string Description { get; set; }
+    [JsonProperty("guidence")]
+    public string Guidence { get; set; } = null;
+    [JsonProperty("plannedFixDate")]
+    public DateOnly? PlannedFixDate { get; set; } = null;
+    /// <summary>
+    /// updatedAt angir når den konkrete begrensningen sist ble faglig oppdatert i grunnlagsdataene
+    /// </summary>
+    [JsonProperty("updatedAt")]
+    public DateOnly? UpdatedAt { get; set; }
 }

--- a/src/Dan.Plugin.Bits/Models/Endpoints.cs
+++ b/src/Dan.Plugin.Bits/Models/Endpoints.cs
@@ -84,7 +84,8 @@ public class Limitation
     [JsonProperty("area")]
     public string Area{ get; set; }
     [JsonProperty("apiResponseStatus")]
-    public string? ApiResponseStatus { get; set; } = null;
+    [JsonConverter(typeof(ApiResponseStatusConverter))]
+    public ApiResponseStatus? ApiResponseStatus { get; set; } = null;
     [JsonProperty("description")]
     public string Description { get; set; }
     [JsonProperty("guidence")]
@@ -96,4 +97,13 @@ public class Limitation
     /// </summary>
     [JsonProperty("updatedAt")]
     public DateOnly? UpdatedAt { get; set; }
+}
+
+public enum ApiResponseStatus
+{
+    Partial,
+    Complete,
+    DataNotDelivered,
+    NotApplicable,
+    Unknown
 }

--- a/src/Dan.Plugin.Bits/Plugin.cs
+++ b/src/Dan.Plugin.Bits/Plugin.cs
@@ -29,7 +29,7 @@ public class Plugin
     private readonly IMemoryCacheProvider _memCache;
     private readonly IControlInformationService _controlInformationService;
     private const string ENDPOINTS_KEY = "endpoints_key";
-    private static readonly Regex NorwegianOrganizationNumberPattern = new(@"^\d{9}$", RegexOptions.Compiled);
+    private static readonly Regex NorwegianOrganizationNumberPattern = new(@"\A[0-9]{9}\z", RegexOptions.Compiled);
 
 
     public Plugin(IOptions<Settings> settings, IControlInformationService controlInformationService, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, IMemoryCacheProvider memCache)

--- a/src/Dan.Plugin.Bits/Plugin.cs
+++ b/src/Dan.Plugin.Bits/Plugin.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 using Dan.Common.Exceptions;
 using Dan.Common.Models;
@@ -11,12 +10,12 @@ using Dan.Common.Util;
 using Dan.Plugin.Bits.Config;
 using Dan.Plugin.Bits.Models;
 using Dan.Plugin.Bits.Services;
-using FileHelpers;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Microsoft.Extensions.Options;
 
 namespace Dan.Plugin.Bits;
@@ -31,6 +30,7 @@ public class Plugin
     private readonly IMemoryCacheProvider _memCache;
     private readonly IControlInformationService _controlInformationService;
     private const string ENDPOINTS_KEY = "endpoints_key";
+    private static readonly Regex NorwegianOrganizationNumberPattern = new(@"^\d{9}$", RegexOptions.Compiled);
 
 
     public Plugin(IOptions<Settings> settings, IControlInformationService controlInformationService, ILoggerFactory loggerFactory, IHttpClientFactory httpClientFactory, IMemoryCacheProvider memCache)
@@ -122,11 +122,11 @@ public class Plugin
         try
         {
             var evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
-            var orgNo = evidenceHarvesterRequest?.SubjectParty.NorwegianOrganizationNumber;
+            var orgNo = evidenceHarvesterRequest?.SubjectParty?.NorwegianOrganizationNumber;
 
-            if (string.IsNullOrWhiteSpace(orgNo))
+            if (string.IsNullOrWhiteSpace(orgNo) || !NorwegianOrganizationNumberPattern.IsMatch(orgNo))
             {
-                throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput, "Organisasjonsnummer mangler i forespørselen");
+                throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput, "Organisasjonsnummer mangler eller er ugyldig i forespørselen");
             }
 
             var ecb = new EvidenceBuilder(new Metadata(), PluginConstants.Limitations);

--- a/src/Dan.Plugin.Bits/Plugin.cs
+++ b/src/Dan.Plugin.Bits/Plugin.cs
@@ -179,7 +179,7 @@ public class Plugin
            [HttpTrigger(AuthorizationLevel.Function, "get")] HttpRequestData req,
            FunctionContext context)
     {
-        var endpoints = await _controlInformationService.ReadEndpointsAndCache();
+        var endpoints = await _controlInformationService.ReadEndpointsAndCacheWithLimitations();
 
         var response = req.CreateResponse(HttpStatusCode.OK);
         await response.WriteAsJsonAsync(new EndpointsList() { Endpoints = endpoints, Total = endpoints.Count });

--- a/src/Dan.Plugin.Bits/Plugin.cs
+++ b/src/Dan.Plugin.Bits/Plugin.cs
@@ -14,7 +14,6 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.Azure.Functions.Worker.Http;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using System.Linq;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Options;
 
@@ -85,14 +84,8 @@ public class Plugin
         try
         {
             var ecb = new EvidenceBuilder(new Metadata(), PluginConstants.Kontrollinformasjon);
+            // GetBankEndpointsWithDates already attaches limitations per endpoint - see ControlInformationService.
             var endpoints = await _controlInformationService.GetBankEndpointsWithDates();
-
-            foreach (var endpoint in endpoints)
-            {
-                var limitations = await _controlInformationService.GetBankLimitations(endpoint.OrgNo);
-                endpoint.Limitations = limitations.ToList();
-            }
-
             var json = JsonConvert.SerializeObject(endpoints);
             ecb.AddEvidenceValue(PluginConstants.DefaultValue, json, PluginConstants.SourceName, false);
             return ecb.GetEvidenceValues();

--- a/src/Dan.Plugin.Bits/Plugin.cs
+++ b/src/Dan.Plugin.Bits/Plugin.cs
@@ -86,6 +86,13 @@ public class Plugin
         {
             var ecb = new EvidenceBuilder(new Metadata(), PluginConstants.Kontrollinformasjon);
             var endpoints = await _controlInformationService.GetBankEndpointsWithDates();
+
+            foreach (var endpoint in endpoints)
+            {
+                var limitations = await _controlInformationService.GetBankLimitations(endpoint.OrgNo);
+                endpoint.Limitations = limitations.ToList();
+            }
+
             var json = JsonConvert.SerializeObject(endpoints);
             ecb.AddEvidenceValue(PluginConstants.DefaultValue, json, PluginConstants.SourceName, false);
             return ecb.GetEvidenceValues();
@@ -98,6 +105,48 @@ public class Plugin
         catch (Exception e)
         {
             _logger.LogError(e, "Unable to fetch bank endpoints: {message}", e.Message);
+            throw new EvidenceSourceTransientException(PluginConstants.ErrorUpstreamUnavailble, e.Message, e);
+        }
+    }
+
+    [Function(PluginConstants.Limitations)]
+    public async Task<HttpResponseData> GetLimitations(
+        [HttpTrigger(AuthorizationLevel.Function, "post")] HttpRequestData req,
+        FunctionContext context)
+    {
+        return await EvidenceSourceResponse.CreateResponse(req, () => GetEvidenceValuesLimitations(req));
+    }
+
+    private async Task<List<EvidenceValue>> GetEvidenceValuesLimitations(HttpRequestData req)
+    {
+        try
+        {
+            var evidenceHarvesterRequest = await req.ReadFromJsonAsync<EvidenceHarvesterRequest>();
+            var orgNo = evidenceHarvesterRequest?.SubjectParty.NorwegianOrganizationNumber;
+
+            if (string.IsNullOrWhiteSpace(orgNo))
+            {
+                throw new EvidenceSourcePermanentClientException(PluginConstants.ErrorInvalidInput, "Organisasjonsnummer mangler i forespørselen");
+            }
+
+            var ecb = new EvidenceBuilder(new Metadata(), PluginConstants.Limitations);
+            var limitations = await _controlInformationService.GetBankLimitations(orgNo);
+            var json = JsonConvert.SerializeObject(new LimitationsList { Limitations = limitations, Total = limitations.Count });
+            ecb.AddEvidenceValue(PluginConstants.DefaultValue, json, PluginConstants.SourceName, false);
+            return ecb.GetEvidenceValues();
+        }
+        catch (JsonSerializationException e)
+        {
+            _logger.LogError(e, "Unable to parse limitations response: {message}", e.Message);
+            throw new EvidenceSourceTransientException(PluginConstants.ErrorUnableToParseResponse, e.Message, e);
+        }
+        catch (EvidenceSourceException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            _logger.LogError(e, "Unable to fetch limitations: {message}", e.Message);
             throw new EvidenceSourceTransientException(PluginConstants.ErrorUpstreamUnavailble, e.Message, e);
         }
     }

--- a/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
+++ b/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
@@ -13,6 +13,7 @@ using Dan.Plugin.Bits.Models;
 using FileHelpers;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
 
 namespace Dan.Plugin.Bits.Services;
 
@@ -26,6 +27,7 @@ public interface IControlInformationService
     Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCachePantUtlegg();
 
     Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCache();
+    Task<IReadOnlyList<Limitation>> GetBankLimitations(string orgNo);
 }
 
 public class ControlInformationService(
@@ -40,6 +42,7 @@ public class ControlInformationService(
 
     private const string EndpointsKey = "endpoints_key";
     private const string PantUtleggKey = "pantutlegg_key";
+    private const string LimitationsKeyPrefix = "limitations_key";
     private const int ErrorKeyTemp = 1;
 
     public async Task<IReadOnlyList<EndpointExternal>> GetBankEndpoints()
@@ -113,6 +116,26 @@ public class ControlInformationService(
         return await ReadEndpointsFromGithubAndCache(settings.PantUtleggResourceFile, PantUtleggKey, "PantUtlegg endpoints");
     }
 
+    public async Task<IReadOnlyList<Limitation>> ReadLimitationsAndCache(string orgNo)
+    {
+        return await ReadLimitationsFromGithubAndCache(settings.LimitationsResourceFile ,orgNo, $"{LimitationsKeyPrefix}{orgNo}", "Limitations");
+    }
+
+    public async Task<IReadOnlyList<Limitation>> GetBankLimitations(string orgNo)
+    {
+        var cacheKey = $"{LimitationsKeyPrefix}{orgNo}";
+        var (hasCachedValue, limitations) = await memCache.TryGetLimitations(cacheKey);
+
+        if (!hasCachedValue)
+        {
+            logger.LogInformation("No limitations found in cache for {orgNo}", orgNo);
+            limitations = await ReadLimitationsAndCache(orgNo);
+        }
+
+        logger.LogInformation("Returning total of {totalRecords} limitations for {orgNo} read from cache", limitations.Count, orgNo);
+        return limitations;
+    }
+
     private async Task<IReadOnlyList<EndpointExternal>> ReadEndpointsFromGithubAndCache(string resourceFilePath, string cacheKey, string resourceName)
     {
         try
@@ -146,10 +169,37 @@ public class ControlInformationService(
         }
     }
 
-    private async Task<string> GetFileFromGithub(string filePath)
+    private async Task<IReadOnlyList<Limitation>> ReadLimitationsFromGithubAndCache(string resourceFile, string orgNo, string cacheKey, string resourceName)
+    {
+        try
+        {
+            var file = await GetFileFromGithub(resourceFile + $"{orgNo}.json", allowNotFound: true);
+            if (file == null)
+            {
+                logger.LogInformation("No {resourceName} file found on GitHub for {orgNo} at {resourceFile}", resourceName, orgNo, resourceFile);
+                return memCache.SetLimitationsCache(cacheKey, [], TimeSpan.FromMinutes(300));
+            }
+            
+
+            var limitations = JsonConvert.DeserializeObject<List<Limitation>>(file) ?? [];
+            var result = memCache.SetLimitationsCache(cacheKey, limitations, TimeSpan.FromMinutes(300));
+            logger.LogInformation("Cache refresh completed for {resourceName} ({cacheKey}) - total of {totalRecords} cached",
+                resourceName, cacheKey, limitations.Count);
+
+            return result;
+        }
+        catch (Exception ex)
+        {
+            logger.LogCritical(ex, "Unable to fetch or parse {resourceName} for {orgNo} from {resourceFile}: {message}",
+                resourceName, orgNo, resourceFile, ex.Message);
+            throw new EvidenceSourceTransientException(ErrorKeyTemp, $"{resourceName} are currently unavailable", ex);
+        }
+    }
+
+    private async Task<string> GetFileFromGithub(string filePath, bool allowNotFound = false)
     {
         var url = $"https://api.github.com/repos/data-altinn-no/bits/contents/{filePath}";
-        
+
         using var request = new HttpRequestMessage(HttpMethod.Get, url);
         request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.raw+json"));
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", settings.GithubPat);
@@ -163,7 +213,12 @@ public class ControlInformationService(
             return await response.Content.ReadAsStringAsync();
         }
 
-        logger.LogCritical("Github retrieval failed for {filePath}, status code: {StatusCode}, reason: {ReasonPhrase}", 
+        if (allowNotFound && response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        logger.LogCritical("Github retrieval failed for {filePath}, status code: {StatusCode}, reason: {ReasonPhrase}",
             filePath, response.StatusCode, response.ReasonPhrase);
         throw new EvidenceSourceTransientException(ErrorKeyTemp, "Banking endpoints are currently unavailable");
     }

--- a/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
+++ b/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
@@ -27,6 +27,7 @@ public interface IControlInformationService
     Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCachePantUtlegg();
 
     Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCache();
+    Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCacheWithLimitations();
     Task<IReadOnlyList<Limitation>> GetBankLimitations(string orgNo);
 }
 
@@ -111,10 +112,7 @@ public class ControlInformationService(
         // here rather than in GetBankEndpoints. This mutates the EndpointExternal instances that live in the
         // shared endpoints cache, so once populated they stay attached to those objects until the cache entry
         // itself expires/refreshes - subsequent calls don't need to re-fetch limitations for the same endpoints.
-        foreach (var endpoint in activeEndpoints)
-        {
-            endpoint.Limitations = (await GetBankLimitations(endpoint.OrgNo)).ToList();
-        }
+        await AttachLimitations(activeEndpoints);
 
         return activeEndpoints;
     }
@@ -123,6 +121,24 @@ public class ControlInformationService(
     public async Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCache()
     {
         return await ReadEndpointsFromGithubAndCache(settings.EndpointsResourceFile, EndpointsKey, "Bank endpoints");
+    }
+
+    public async Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCacheWithLimitations()
+    {
+        var endpoints = await ReadEndpointsAndCache();
+        var activeEndpoints = endpoints.Where(x => x.ToDate == null || x.ToDate >= DateTime.UtcNow);
+
+        await AttachLimitations(activeEndpoints);
+
+        return endpoints;
+    }
+
+    private async Task AttachLimitations(IEnumerable<EndpointExternal> endpoints)
+    {
+        foreach (var endpoint in endpoints)
+        {
+            endpoint.Limitations = (await GetBankLimitations(endpoint.OrgNo)).ToList();
+        }
     }
 
     public async Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCachePantUtlegg()

--- a/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
+++ b/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
@@ -58,6 +58,7 @@ public class ControlInformationService(
         logger.LogInformation("Returning total of {totalRecords} endpoints read from cache", endpoints.Count);
 
         //remove endpoints that are not currently active, they are returned only in KontrollinformasjonUtvidet
+        //Limitations are only included in KontrollinformasjonUtvidet.
         return endpoints.Where(x =>
             (x.FromDate == null || x.FromDate <= DateTime.UtcNow) &&
             (x.ToDate == null || x.ToDate >= DateTime.UtcNow))
@@ -69,7 +70,8 @@ public class ControlInformationService(
                 Version = x.Version,
                 ToDate = null,
                 FromDate = null,
-                Name = x.Name
+                Name = x.Name,
+                Limitations = null
              })
             .ToList();
     }
@@ -101,8 +103,20 @@ public class ControlInformationService(
         }
 
         logger.LogInformation("Returning total of {totalRecords} endpoints read from cache", endpoints.Count);
-        return endpoints.Where(x =>
+
+        var activeEndpoints = endpoints.Where(x =>
             (x.ToDate == null || x.ToDate >= DateTime.UtcNow)).ToList();
+
+        // KontrollinformasjonUtvidet is the only dataset that should carry limitations, so they're attached
+        // here rather than in GetBankEndpoints. This mutates the EndpointExternal instances that live in the
+        // shared endpoints cache, so once populated they stay attached to those objects until the cache entry
+        // itself expires/refreshes - subsequent calls don't need to re-fetch limitations for the same endpoints.
+        foreach (var endpoint in activeEndpoints)
+        {
+            endpoint.Limitations = (await GetBankLimitations(endpoint.OrgNo)).ToList();
+        }
+
+        return activeEndpoints;
     }
 
 

--- a/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
+++ b/src/Dan.Plugin.Bits/Services/ControlInformationService.cs
@@ -60,9 +60,7 @@ public class ControlInformationService(
 
         //remove endpoints that are not currently active, they are returned only in KontrollinformasjonUtvidet
         //Limitations are only included in KontrollinformasjonUtvidet.
-        return endpoints.Where(x =>
-            (x.FromDate == null || x.FromDate <= DateTime.UtcNow) &&
-            (x.ToDate == null || x.ToDate >= DateTime.UtcNow))
+        return endpoints.Where(IsActiveEndpoint)
              .Select(x => new EndpointExternal
              {
                 Env = x.Env,
@@ -105,8 +103,7 @@ public class ControlInformationService(
 
         logger.LogInformation("Returning total of {totalRecords} endpoints read from cache", endpoints.Count);
 
-        var activeEndpoints = endpoints.Where(x =>
-            (x.ToDate == null || x.ToDate >= DateTime.UtcNow)).ToList();
+        var activeEndpoints = endpoints.Where(IsActiveEndpoint).ToList();
 
         // KontrollinformasjonUtvidet is the only dataset that should carry limitations, so they're attached
         // here rather than in GetBankEndpoints. This mutates the EndpointExternal instances that live in the
@@ -126,7 +123,7 @@ public class ControlInformationService(
     public async Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCacheWithLimitations()
     {
         var endpoints = await ReadEndpointsAndCache();
-        var activeEndpoints = endpoints.Where(x => x.ToDate == null || x.ToDate >= DateTime.UtcNow);
+        var activeEndpoints = endpoints.Where(IsActiveEndpoint);
 
         await AttachLimitations(activeEndpoints);
 
@@ -140,6 +137,10 @@ public class ControlInformationService(
             endpoint.Limitations = (await GetBankLimitations(endpoint.OrgNo)).ToList();
         }
     }
+   
+    private static bool IsActiveEndpoint(EndpointExternal x) =>
+        (x.FromDate == null || x.FromDate <= DateTime.UtcNow) &&
+        (x.ToDate == null || x.ToDate >= DateTime.UtcNow);
 
     public async Task<IReadOnlyList<EndpointExternal>> ReadEndpointsAndCachePantUtlegg()
     {

--- a/src/Dan.Plugin.Bits/Services/MemoryCacheProvider.cs
+++ b/src/Dan.Plugin.Bits/Services/MemoryCacheProvider.cs
@@ -12,8 +12,10 @@ namespace Dan.Plugin.Bits.Services;
 public interface IMemoryCacheProvider
 {
     public Task<(bool success, IReadOnlyList<EndpointExternal> result)> TryGetEndpoints(string key);
+    public Task<(bool success, IReadOnlyList<Limitation> result)> TryGetLimitations(string key);
 
     public List<EndpointExternal> SetEndpointsCache(string key, List<EndpointV2> value, TimeSpan timeToLive);
+    public List<Limitation> SetLimitationsCache(string key, List<Limitation> value, TimeSpan timeToLive);
 }
 
 public class MemoryCacheProvider(IMemoryCache memoryCache, IOptions<Settings> settings) : IMemoryCacheProvider
@@ -26,6 +28,12 @@ public class MemoryCacheProvider(IMemoryCache memoryCache, IOptions<Settings> se
         return (success, result);
     }
 
+    public async Task<(bool success, IReadOnlyList<Limitation> result)> TryGetLimitations(string key)
+    {
+        var success = memoryCache.TryGetValue(key, out IReadOnlyList<Limitation> result);
+        return (success, result);
+    }
+
     public List<EndpointExternal> SetEndpointsCache(string key, List<EndpointV2> value, TimeSpan timeToLive)
     {
         var cacheEntryOptions = new MemoryCacheEntryOptions()
@@ -35,6 +43,19 @@ public class MemoryCacheProvider(IMemoryCache memoryCache, IOptions<Settings> se
 
         cacheEntryOptions.SetAbsoluteExpiration(timeToLive);
         var result = memoryCache.Set(key, MapToExternal(value), cacheEntryOptions);
+
+        return result;
+    }
+
+    public List<Limitation> SetLimitationsCache(string key, List<Limitation> value, TimeSpan timeToLive)
+    {
+        var cacheEntryOptions = new MemoryCacheEntryOptions()
+        {
+            Priority = CacheItemPriority.High,
+        };
+
+        cacheEntryOptions.SetAbsoluteExpiration(timeToLive);
+        var result = memoryCache.Set(key, value, cacheEntryOptions);
 
         return result;
     }


### PR DESCRIPTION
### Description
<!--- What and why -->

- Added Limitations to KontrollinformasjonV2/KontrollinformasjonUtvidet.
- Added new function for getting Limitations by organizationNumber

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving organization-specific bank limitations.
  - Added an endpoint for viewing limitations, including descriptions, statuses, planned resolution dates, and update dates.
  - Endpoint evidence responses now include applicable limitations.
  - Added recognized limitation statuses: partial, complete, data not delivered, not applicable, and unknown.
  - Added caching to improve limitation retrieval performance.
  - Missing limitation files are handled gracefully as empty results.
  - Limitations are included only for currently active endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->