### PR TITLE
made some fields optional and removed customerconverter for enum

### DIFF
--- a/src/Dan.Plugin.Bits/Models/CustomConverters.cs
+++ b/src/Dan.Plugin.Bits/Models/CustomConverters.cs
@@ -5,42 +5,6 @@ using Newtonsoft.Json;
 
 
 namespace Dan.Plugin.Bits.Models;
-
-// Deserializes an apiResponseStatus string against the ApiResponseStatus enum.
-// Unrecognized value falls back to ApiResponseStatus.Unknown
-public sealed class ApiResponseStatusConverter : JsonConverter
-{
-    public override bool CanConvert(Type objectType)
-    {
-        return objectType == typeof(ApiResponseStatus) || objectType == typeof(ApiResponseStatus?);
-    }
-
-    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-    {
-        if (reader.TokenType == JsonToken.Null)
-            return null;
-
-        var text = reader.Value?.ToString();
-
-        if (string.IsNullOrWhiteSpace(text))
-            return null;
-
-        return Enum.TryParse<ApiResponseStatus>(text, ignoreCase: true, out var status) ? status : ApiResponseStatus.Unknown;
-    }
-
-    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-    {
-        if (value == null)
-        {
-            writer.WriteNull();
-        }
-        else
-        {
-            writer.WriteValue(value.ToString());
-        }
-    }
-}
-
 public sealed class DateTimeOffsetConverter : ConverterBase
 {
     private static readonly string[] Formats =

--- a/src/Dan.Plugin.Bits/Models/Endpoints.cs
+++ b/src/Dan.Plugin.Bits/Models/Endpoints.cs
@@ -91,18 +91,17 @@ public class Limitation
     /// </summary>
     [JsonProperty("apiResponseStatus")]
     [FieldOptional]
-    public string ApiResponseStatus { get; set; }
+    public string? ApiResponseStatus { get; set; }
     [JsonProperty("description")]
     public string Description { get; set; }
     [JsonProperty("guidance")]
-    public string Guidance { get; set; }
+    public string? Guidance { get; set; }
     [JsonProperty("plannedFixDate")]
     [FieldOptional]
-    public DateOnly? PlannedFixDate { get; set; }
+    public string? PlannedFixDate { get; set; }
     /// <summary>
     /// updatedAt angir når den konkrete begrensningen sist ble faglig oppdatert i grunnlagsdataene
     /// </summary>
     [JsonProperty("updatedAt")]
-    [FieldOptional]
-    public DateOnly? UpdatedAt { get; set; }
+    public string UpdatedAt { get; set; }
 }

--- a/src/Dan.Plugin.Bits/Models/Endpoints.cs
+++ b/src/Dan.Plugin.Bits/Models/Endpoints.cs
@@ -80,30 +80,29 @@ public class Limitation
     [JsonProperty("limitationId")]
     public string LimitationId { get; set; }
     [JsonProperty("limitationGroupId")]
-    public string? LimitationGroupId { get; set; } = null;
+    [FieldOptional]
+    public string? LimitationGroupId { get; set; }
     [JsonProperty("area")]
-    public string Area{ get; set; }
+    [FieldOptional]
+    public string? Area{ get; set; }
+    /// <summary>
+    /// Vanligvis Complete or Partial. Test data følger ikke reglene for hva ApiResponseStatus
+    /// kan være og er derfor en string for å unngå crash.
+    /// </summary>
     [JsonProperty("apiResponseStatus")]
-    [JsonConverter(typeof(ApiResponseStatusConverter))]
-    public ApiResponseStatus? ApiResponseStatus { get; set; } = null;
+    [FieldOptional]
+    public string ApiResponseStatus { get; set; }
     [JsonProperty("description")]
     public string Description { get; set; }
-    [JsonProperty("guidence")]
-    public string Guidence { get; set; } = null;
+    [JsonProperty("guidance")]
+    public string Guidance { get; set; }
     [JsonProperty("plannedFixDate")]
-    public DateOnly? PlannedFixDate { get; set; } = null;
+    [FieldOptional]
+    public DateOnly? PlannedFixDate { get; set; }
     /// <summary>
     /// updatedAt angir når den konkrete begrensningen sist ble faglig oppdatert i grunnlagsdataene
     /// </summary>
     [JsonProperty("updatedAt")]
+    [FieldOptional]
     public DateOnly? UpdatedAt { get; set; }
-}
-
-public enum ApiResponseStatus
-{
-    Partial,
-    Complete,
-    DataNotDelivered,
-    NotApplicable,
-    Unknown
 }


### PR DESCRIPTION
### Description
<!--- What and why -->
Made ApiResponseStatys string to prevent crashes when testdata is wrong
Removed customerConverter for Enum.
Made some fields nullable and added FieldOptional property.

### Documentation
- [x] Doc updated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved limitation data handling for responses containing status values outside the previously supported set.
  * Improved CSV import compatibility by supporting optional limitation fields, missing area values, and flexible date formats.
  * Corrected the guidance field name to match the expected data format.
  * Improved compatibility with limitation records that provide dates and status information as text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->